### PR TITLE
Update dependabot PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
To account for an increase in churn to dependencies.